### PR TITLE
Use longest match in OR

### DIFF
--- a/yargy/normalization.py
+++ b/yargy/normalization.py
@@ -66,5 +66,5 @@ def get_inflected_text(tokens, required_grammemes, morph_analyzer=Analyzer, deli
             )
     return delimiter.join(words)
 
-def get_normalized_text(tokens, morph_analyzer=Analyzer):
-    return get_inflected_text(tokens, {'nomn', 'sing'})
+def get_normalized_text(tokens, morph_analyzer=Analyzer, delimiter=' '):
+    return get_inflected_text(tokens, {'nomn', 'sing'}, morph_analyzer, delimiter)


### PR DESCRIPTION
Partial fix for #13

Это не полное решение для #13. Оно только позволяет сделать нормальные грамматики для адресов https://github.com/bureaucratic-labs/natasha/issues/9

Вот пример грамматики, которая не будет работать `(а|а б в) б д`. Строчка `а б д` не заметчится.

Как сделать хорошее полное решение для OR и вообще для рекурсивных грамматик с текущей реализацией парсера я не очень представляю.